### PR TITLE
Mejora del calculo de la posicion cinco del CINI de fiabilidad

### DIFF
--- a/cini/models.py
+++ b/cini/models.py
@@ -806,7 +806,7 @@ class Fiabilidad(Base):
 
     TIPO_INTERRUPTORES = {
         '0': '2',
-        '1': '3',
+        '1': '2',
         '2': '3'
     }
 

--- a/cini/models.py
+++ b/cini/models.py
@@ -804,6 +804,12 @@ class Fiabilidad(Base):
         'P': '2'
     }
 
+    TIPO_INTERRUPTORES = {
+        '0': '2',
+        '1': '3',
+        '2': '3'
+    }
+
     SITUACIONES = {
         'SE': '1',
         'CT': '2',
@@ -820,6 +826,7 @@ class Fiabilidad(Base):
         self.tension = None
         self.tipo = None
         self.tipo_posicion = None
+        self.tipo_interruptor = None
         self.telemando = None
         self.situacion = None
         self.aislante = None
@@ -843,8 +850,9 @@ class Fiabilidad(Base):
                 c.positions[3] = self.TENSIONES[self.situacion][1]
             elif 1 <= self.tension < 36:
                 c.positions[3] = self.TENSIONES[self.situacion][2]
-        if self.situacion in ('CT', 'SE'):
-            c.positions[4] = '2'
+        if self.situacion in ('CT', 'SE') and self.tipo_interruptor:
+            c.positions[4] = (
+                self.TIPO_INTERRUPTORES.get(self.tipo_interruptor, '2'))
         else:
             c.positions[4] = '0'
         if self.situacion == 'LAT' and self.tipo:

--- a/spec/fiabilidad_spec.py
+++ b/spec/fiabilidad_spec.py
@@ -97,22 +97,36 @@ with description('Calculando el CINI de un elemento de fiabiliadd'):
                         expect(cini[3]).to(equal('C'))
 
     with description('la cuarta posición'):
-        with context('Si está en un CT'):
-            with it('must be 2'):
-                l = Fiabilidad()
-                l.situacion = 'CT'
-                l.tipo = 'S'
-                cini = l.cini
-                expect(cini[4]).to(equal('2'))
-        with context('Si está en una SE'):
-            with it('must be 2'):
-                l = Fiabilidad()
-                l.situacion = 'SE'
-                l.tipo = 'R'
-                cini = l.cini
-                expect(cini[4]).to(equal('2'))
         with before.all:
             self.fiab = Fiabilidad()
+        with context('Si está en un CT'):
+            with it('must be 2'):
+                self.fiab.situacion = 'CT'
+                self.fiab.tipo = 'S'
+                for int in ['0', '1']:
+                    self.fiab.tipo_interruptor = int
+                    cini = self.fiab.cini
+                    expect(cini[4]).to(equal('2'))
+            with it('must be 3'):
+                self.fiab.situacion = 'CT'
+                self.fiab.tipo = 'S'
+                self.fiab.tipo_interruptor = '2'
+                cini = self.fiab.cini
+                expect(cini[4]).to(equal('3'))
+        with context('Si está en una SE'):
+            with it('must be 2'):
+                self.fiab.situacion = 'SE'
+                self.fiab.tipo = 'R'
+                for int in ['0', '1']:
+                    self.fiab.tipo_interruptor = int
+                    cini = self.fiab.cini
+                    expect(cini[4]).to(equal('2'))
+            with it('must be 3'):
+                self.fiab.situacion = 'SE'
+                self.fiab.tipo = 'R'
+                self.fiab.tipo_interruptor = '2'
+                cini = self.fiab.cini
+                expect(cini[4]).to(equal('3'))
         with it('must be 0'):
             cini = self.fiab.cini
             expect(cini[4]).to(equal('0'))


### PR DESCRIPTION
# Objetivo
En el momento de hacer el cálculo de la posición 5 del código CINI de Fiabilidad se deb serguir la siguiente lógica:

- En caso de ser un tipo de elemento interruptor `0: Con interruptor automático` o bien `1: Con interruptor no automático` debe ser un `2: Posición con interruptor`. 
- En caso de ser un tipo de elemento interruptor `2:  Sin interruptor` debe ser `3: Posición sin interruptor`

# Relacionado
- Origen de la tarea: TASK-71908