### PR TITLE
Asegurar que la posicion 5 del CINI de CTs no es None

### DIFF
--- a/cini/models.py
+++ b/cini/models.py
@@ -410,7 +410,7 @@ class CentroTransformador(Base):
             'S': '4',
             'M': '9'
         }
-        c.positions[5] = tipo_map.get(self.tipo)
+        c.positions[5] = tipo_map.get(self.tipo, ' ')
 
         if self.tension is not None:
             if self.tension <= 1:

--- a/cini/models.py
+++ b/cini/models.py
@@ -403,14 +403,16 @@ class CentroTransformador(Base):
         if self.tension_s is not None and self.tension_s < 1:
             c.positions[4] = '5'
 
-        tipo_map = {
-            'I': '1',
-            'C': '2',
-            'L': '3',
-            'S': '4',
-            'M': '9'
-        }
-        c.positions[5] = tipo_map.get(self.tipo, ' ')
+        if self.tipo == 'I':
+            c.positions[5] = '1'
+        elif self.tipo == 'C':
+            c.positions[5] = '2'
+        elif self.tipo == 'L':
+            c.positions[5] = '3'
+        elif self.tipo == 'S':
+            c.positions[5] = '4'
+        elif self.tipo == 'M':
+            c.positions[5] = '9'
 
         if self.tension is not None:
             if self.tension <= 1:


### PR DESCRIPTION
Arreglo de un bug que entra en https://github.com/gisce/cini/pull/38 cuando no se encuentra un tipo válido de CT. 

Antes no seteaba el valor de la posición 5 si no encontraba el tipo y el cambio introducido lo seteaba siempre al valor de self.tipo, incluso a None. Se hecha para atrás.