### PR TITLE
Corregir classificación que se hacen respecto a los CT

### DIFF
--- a/cini/models.py
+++ b/cini/models.py
@@ -822,6 +822,7 @@ class Fiabilidad(Base):
         self.telemando = None
         self.situacion = None
         self.aislante = None
+        self.tipus_ct = None
 
     @property
     def cini(self):
@@ -850,10 +851,16 @@ class Fiabilidad(Base):
         if self.situacion == 'LAT' and self.tipo:
             c.positions[5] = self.TIPOS.get(self.tipo, ' ')
         elif self.situacion in ('CT', 'SE') and self.aislante:
-            if self.aislante.upper() == 'AIRE':
-                c.positions[5] = 'C'
-            else:
-                c.positions[5] = 'A'
+            if self.tipus_ct and self.tipus_ct.upper() == 'INTEMPERIE':
+                if self.aislante.upper() == 'AIRE':
+                    c.positions[5] = 'D'
+                else:
+                    c.positions[5] = 'B'
+            else:  # En el cas de ser un 'Interior' o SE.
+                if self.aislante.upper() == 'AIRE':
+                    c.positions[5] = 'C'
+                else:
+                    c.positions[5] = 'A'
         if self.situacion == 'LAT' and self.telemando is not None:
             if self.telemando:
                 c.positions[6] = '2'

--- a/spec/fiabilidad_spec.py
+++ b/spec/fiabilidad_spec.py
@@ -175,30 +175,64 @@ with description('Calculando el CINI de un elemento de fiabiliadd'):
             with before.all:
                 self.fiab = Fiabilidad()
                 self.fiab.situacion = 'CT'
-            with context('el aislante es AIRE'):
-                with it('must be C'):
-                    self.fiab.aislante = 'aire'
-                    cini = self.fiab.cini
-                    expect(cini[5]).to(equal('C'))
-            with context('los otros casos'):
-                with it('must be A'):
-                    self.fiab.aislante = 'sf6'
-                    cini = self.fiab.cini
-                    expect(cini[5]).to(equal('A'))
-        with context('Si es una SE'):
+                self.fiab.tipus_ct = 'INTEMPERIE'
+                with context('el tipo de CT es INTEMPERIE'):
+                    with context('el aislante es AIRE'):
+                        with it('must be D'):
+                            self.fiab.aislante = 'aire'
+                            cini = self.fiab.cini
+                            expect(cini[5]).to(equal('D'))
+                    with context('los otros casos'):
+                        with it('must be B'):
+                            self.fiab.aislante = 'sf6'
+                            cini = self.fiab.cini
+                        expect(cini[5]).to(equal('B'))
+            with before.all:
+                self.fiab = Fiabilidad()
+                self.fiab.situacion = 'CT'
+                self.fiab.tipus_ct = 'INTERIOR'
+                with context('el tipo de CT es INTERIOR'):
+                    with context('el aislante es AIRE'):
+                        with it('must be C'):
+                            self.fiab.aislante = 'aire'
+                            cini = self.fiab.cini
+                            expect(cini[5]).to(equal('C'))
+                    with context('los otros casos'):
+                        with it('must be A'):
+                            self.fiab.aislante = 'sf6'
+                            cini = self.fiab.cini
+                        expect(cini[5]).to(equal('A'))
+        with context('Si es un CT'):
             with before.all:
                 self.fiab = Fiabilidad()
                 self.fiab.situacion = 'SE'
-            with context('el aislante es AIRE'):
-                with it('must be C'):
-                    self.fiab.aislante = 'aire'
-                    cini = self.fiab.cini
-                    expect(cini[5]).to(equal('C'))
-            with context('los otros casos'):
-                with it('must be A'):
-                    self.fiab.aislante = 'sf6'
-                    cini = self.fiab.cini
-                    expect(cini[5]).to(equal('A'))
+                self.fiab.tipus_ct = 'INTEMPERIE'
+                with context('el tipo de SE es INTEMPERIE'):
+                    with context('el aislante es AIRE'):
+                        with it('must be C'):
+                            self.fiab.aislante = 'aire'
+                            cini = self.fiab.cini
+                            expect(cini[5]).to(equal('C'))
+                    with context('los otros casos'):
+                        with it('must be A'):
+                            self.fiab.aislante = 'sf6'
+                            cini = self.fiab.cini
+                        expect(cini[5]).to(equal('A'))
+            with before.all:
+                self.fiab = Fiabilidad()
+                self.fiab.situacion = 'SE'
+                self.fiab.tipus_ct = 'INTERIOR'
+                with context('el tipo de SE es INTERIOR'):
+                    with context('el aislante es AIRE'):
+                        with it('must be C'):
+                            self.fiab.aislante = 'aire'
+                            cini = self.fiab.cini
+                            expect(cini[5]).to(equal('C'))
+                    with context('los otros casos'):
+                        with it('must be A'):
+                            self.fiab.aislante = 'sf6'
+                            cini = self.fiab.cini
+                        expect(cini[5]).to(equal('A'))
 
     with description('la sexta posición'):
         with context('si es LAT'):


### PR DESCRIPTION
## Objetivo
- Corregir la clasificación que se hace respecto a los CT para que siga esta lógica:

```text
Si CT intemperie:
  Si fluido AIRE >> D
  Sino >> B
Si no CT intemperie (interior):
  Fluido AIRE >> C
  Sino >> A
```

## Relacionado
- Origen de la tarea: [TASK-76035](http://erp-ti.cloudvpn/action?model=project.task&views=%5B%5B1281%2C%22graph%22%5D%2C%5B263%2C%22tree%22%5D%2C%5B1129%2C%22form%22%5D%5D&title=Tasques+fixes+equip&initialView=%7B%22id%22%3A1129%2C%22type%22%3A%22form%22%7D&action_id=1118&action_type=ir.actions.act_window&res_id=76035&treeExpandable=false&limit=80&actionRawData=%7B%22domain%22%3A%22%5B%28%27team_id.member_ids%27%2C+%27in%27%2C+uid%29%2C+%28%27stage_id.name%27%2C+%27%3D%27%2C+%27Permanent%27%29%5D%22%7D)